### PR TITLE
[REFACTOR] [BE] CookieUtil 중앙 집중 형식으로 변경 및 SameSite 설정 추가

### DIFF
--- a/backend/src/main/java/com/ll/hotel/domain/hotel/hotel/service/HotelService.kt
+++ b/backend/src/main/java/com/ll/hotel/domain/hotel/hotel/service/HotelService.kt
@@ -21,12 +21,11 @@ import com.ll.hotel.domain.review.review.dto.response.PresignedUrlsResponse
 import com.ll.hotel.global.annotation.BusinessOnly
 import com.ll.hotel.global.aws.s3.S3Service
 import com.ll.hotel.global.exceptions.ErrorCode
+import com.ll.hotel.global.jwt.dto.JwtProperties
 import com.ll.hotel.standard.util.CookieUtil
 import com.ll.hotel.standard.util.Ut
-import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.hibernate.query.SortDirection
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
@@ -41,8 +40,6 @@ import java.time.LocalDate
 import java.util.*
 import java.util.function.Consumer
 import java.util.function.Supplier
-import kotlin.collections.List
-import kotlin.collections.Set
 import kotlin.collections.set
 import kotlin.math.min
 
@@ -54,7 +51,8 @@ class HotelService(
     private val hotelRepository: HotelRepository,
     private val hotelOptionRepository: HotelOptionRepository,
     private val roomRepository: RoomRepository,
-    private val businessRepository: BusinessRepository
+    private val businessRepository: BusinessRepository,
+    private val jwtProperties: JwtProperties
 ) {
 
     @BusinessOnly
@@ -351,13 +349,14 @@ class HotelService(
                 // 다시 JSON으로 변환하고 URL 인코딩
                 val updatedEncodedData = URLEncoder.encode(Ut.Json.toString(roleData), StandardCharsets.UTF_8)
 
-                // 새 쿠키 생성 및 설정
-                val updatedCookie = Cookie("role", updatedEncodedData)
-                updatedCookie.secure = true
-                updatedCookie.path = "/"
-
-                // 응답에 쿠키 추가
-                response.addCookie(updatedCookie)
+                CookieUtil.addCookie(
+                    response, 
+                    "role", 
+                    updatedEncodedData, 
+                    (jwtProperties.accessTokenExpiration / 1000).toInt(), 
+                    false, 
+                    true
+                )
             } catch (e: Exception) {
                 // 에러 처리
                 e.printStackTrace()

--- a/backend/src/main/java/com/ll/hotel/domain/member/member/service/MemberService.kt
+++ b/backend/src/main/java/com/ll/hotel/domain/member/member/service/MemberService.kt
@@ -14,6 +14,7 @@ import com.ll.hotel.global.response.RsData
 import com.ll.hotel.global.security.oauth2.entity.OAuth
 import com.ll.hotel.global.security.oauth2.repository.OAuthRepository
 import com.ll.hotel.standard.util.Ut
+import com.ll.hotel.standard.util.CookieUtil
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -157,26 +158,10 @@ class MemberService(
     }
 
     private fun deleteCookie(response: HttpServletResponse) {
-        val accessTokenCookie = Cookie("access_token", null)
-        accessTokenCookie.maxAge = 0
-        accessTokenCookie.path = "/"
-
-        val roleCookie = Cookie("role", null)
-        roleCookie.maxAge = 0
-        roleCookie.path = "/"
-
-        val refreshTokenCookie = Cookie("refresh_token", null)
-        refreshTokenCookie.maxAge = 0
-        refreshTokenCookie.path = "/"
-
-        val oauth2AuthRequestCookie = Cookie("oauth2_auth_request", null)
-        oauth2AuthRequestCookie.maxAge = 0
-        oauth2AuthRequestCookie.path = "/"
-
-        response.addCookie(accessTokenCookie)
-        response.addCookie(roleCookie)
-        response.addCookie(refreshTokenCookie)
-        response.addCookie(oauth2AuthRequestCookie)
+        CookieUtil.addCookie(response, "access_token", "", 0, true, true)
+        CookieUtil.addCookie(response, "role", "", 0, false, true)
+        CookieUtil.addCookie(response, "refresh_token", "", 0, true, true)
+        CookieUtil.addCookie(response, "oauth2_auth_request", "", 0, true, true)
     }
 
     fun isLoggedOut(token: String): Boolean {
@@ -283,18 +268,24 @@ class MemberService(
 
     private fun addAuthCookies(response: HttpServletResponse, tokens: GeneratedToken, member: Member) {
         // Access Token 쿠키
-        val accessTokenCookie = Cookie("access_token", tokens.accessToken)
-        accessTokenCookie.path = "/"
-        accessTokenCookie.isHttpOnly = true
-        accessTokenCookie.maxAge = (jwtProperties.accessTokenExpiration / 1000).toInt()
-        response.addCookie(accessTokenCookie)
+        CookieUtil.addCookie(
+            response,
+            "access_token",
+            tokens.accessToken,
+            (jwtProperties.accessTokenExpiration / 1000).toInt(),
+            true,
+            true
+        )
         
         // Refresh Token 쿠키
-        val refreshTokenCookie = Cookie("refresh_token", tokens.refreshToken)
-        refreshTokenCookie.path = "/"
-        refreshTokenCookie.isHttpOnly = true
-        refreshTokenCookie.maxAge = (jwtProperties.refreshTokenExpiration / 1000).toInt()
-        response.addCookie(refreshTokenCookie)
+        CookieUtil.addCookie(
+            response,
+            "refresh_token",
+            tokens.refreshToken,
+            (jwtProperties.refreshTokenExpiration / 1000).toInt(),
+            true,
+            true
+        )
         
         // Role 정보 쿠키
         val roleData = HashMap<String, Any>()
@@ -310,9 +301,13 @@ class MemberService(
             StandardCharsets.UTF_8
         )
         
-        val roleCookie = Cookie("role", encodedRoleData)
-        roleCookie.path = "/"
-        roleCookie.maxAge = (jwtProperties.accessTokenExpiration / 1000).toInt()
-        response.addCookie(roleCookie)
+        CookieUtil.addCookie(
+            response,
+            "role",
+            encodedRoleData,
+            (jwtProperties.accessTokenExpiration / 1000).toInt(),
+            false,
+            true
+        )
     }
 } 

--- a/backend/src/main/java/com/ll/hotel/global/jwt/JwtAuthFilter.kt
+++ b/backend/src/main/java/com/ll/hotel/global/jwt/JwtAuthFilter.kt
@@ -6,9 +6,10 @@ import com.ll.hotel.global.exceptions.ErrorCode.MEMBER_NOT_FOUND
 import com.ll.hotel.global.exceptions.ErrorCode.TOKEN_EXPIRED
 import com.ll.hotel.global.exceptions.ServiceException
 import com.ll.hotel.global.security.oauth2.dto.SecurityUser.Companion.of
+import com.ll.hotel.standard.util.CookieUtil
+import com.ll.hotel.global.jwt.dto.JwtProperties
 import jakarta.servlet.FilterChain
 import jakarta.servlet.ServletException
-import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
@@ -24,7 +25,8 @@ import java.io.IOException
 @Component
 class JwtAuthFilter(
     private val memberService: MemberService,
-    private val memberRepository: MemberRepository
+    private val memberRepository: MemberRepository,
+    private val jwtProperties: JwtProperties
 ) : OncePerRequestFilter(), Ordered {
 
     private val log = LoggerFactory.getLogger(JwtAuthFilter::class.java)
@@ -92,10 +94,16 @@ class JwtAuthFilter(
                         val refreshResult = memberService.refreshAccessToken(refreshToken!!)
                         if (refreshResult.isSuccess) {
                             log.debug("새로운 Access Token 발급 성공")
-                            val newAccessTokenCookie = Cookie("access_token", refreshResult.data)
-                            newAccessTokenCookie.path = "/"
-                            newAccessTokenCookie.isHttpOnly = true
-                            response.addCookie(newAccessTokenCookie)
+                            
+                            // CookieUtil 사용
+                            CookieUtil.addCookie(
+                                response, 
+                                "access_token", 
+                                refreshResult.data!!, 
+                                (jwtProperties.accessTokenExpiration / 1000).toInt(),
+                                true,
+                                true
+                            )
                             
                             val email = memberService.extractEmailIfValid(refreshResult.data!!)
                             val member = memberRepository.findByMemberEmail(email)

--- a/backend/src/main/java/com/ll/hotel/global/jwt/JwtAuthFilter.kt
+++ b/backend/src/main/java/com/ll/hotel/global/jwt/JwtAuthFilter.kt
@@ -95,7 +95,6 @@ class JwtAuthFilter(
                         if (refreshResult.isSuccess) {
                             log.debug("새로운 Access Token 발급 성공")
                             
-                            // CookieUtil 사용
                             CookieUtil.addCookie(
                                 response, 
                                 "access_token", 

--- a/backend/src/main/java/com/ll/hotel/global/security/SecurityConfig.kt
+++ b/backend/src/main/java/com/ll/hotel/global/security/SecurityConfig.kt
@@ -3,6 +3,7 @@ package com.ll.hotel.global.security
 import com.ll.hotel.domain.member.member.repository.MemberRepository
 import com.ll.hotel.domain.member.member.service.MemberService
 import com.ll.hotel.global.jwt.JwtAuthFilter
+import com.ll.hotel.global.jwt.dto.JwtProperties
 import com.ll.hotel.global.jwt.exception.JwtExceptionFilter
 import com.ll.hotel.global.security.cors.CorsProperties
 import com.ll.hotel.global.security.oauth2.CustomOAuth2AuthenticationSuccessHandler
@@ -30,7 +31,8 @@ class SecurityConfig(
     private val memberService: MemberService,
     private val memberRepository: MemberRepository,
     private val customOAuth2AuthorizationRequestRepository: CustomOAuth2AuthorizationRequestRepository,
-    private val corsProperties: CorsProperties
+    private val corsProperties: CorsProperties,
+    private val jwtProperties: JwtProperties
 ) {
 
     @Bean
@@ -113,7 +115,7 @@ class SecurityConfig(
                     .failureHandler(oAuth2AuthenticationFailureHandler)
             }
             .addFilterBefore(JwtExceptionFilter(), UsernamePasswordAuthenticationFilter::class.java)
-            .addFilterBefore(JwtAuthFilter(memberService, memberRepository), UsernamePasswordAuthenticationFilter::class.java)
+            .addFilterBefore(JwtAuthFilter(memberService, memberRepository, jwtProperties), UsernamePasswordAuthenticationFilter::class.java)
 
         return http.build()
     }

--- a/backend/src/main/java/com/ll/hotel/global/security/oauth2/CustomOAuth2AuthenticationSuccessHandler.kt
+++ b/backend/src/main/java/com/ll/hotel/global/security/oauth2/CustomOAuth2AuthenticationSuccessHandler.kt
@@ -2,9 +2,10 @@ package com.ll.hotel.global.security.oauth2
 
 import com.ll.hotel.domain.member.member.service.AuthTokenService
 import com.ll.hotel.domain.member.member.service.MemberService
+import com.ll.hotel.global.jwt.dto.JwtProperties
 import com.ll.hotel.global.security.oauth2.dto.SecurityUser
+import com.ll.hotel.standard.util.CookieUtil
 import com.ll.hotel.standard.util.Ut
-import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
@@ -20,7 +21,8 @@ import java.nio.charset.StandardCharsets
 @Component
 class CustomOAuth2AuthenticationSuccessHandler(
     private val authTokenService: AuthTokenService,
-    private val memberService: MemberService
+    private val memberService: MemberService,
+    private val jwtProperties: JwtProperties
 ) : AuthenticationSuccessHandler {
 
     private val log = LoggerFactory.getLogger(CustomOAuth2AuthenticationSuccessHandler::class.java)
@@ -74,27 +76,37 @@ class CustomOAuth2AuthenticationSuccessHandler(
             }
             val encodedRoleData = URLEncoder.encode(Ut.Json.toString(roleData), StandardCharsets.UTF_8)
 
-            val roleCookie = Cookie("role", encodedRoleData)
-            roleCookie.secure = true
-            roleCookie.path = "/"
-            response.addCookie(roleCookie)
-
-            val accessTokenCookie = Cookie("access_token", accessToken)
-            accessTokenCookie.isHttpOnly = true
-            accessTokenCookie.secure = true
-            accessTokenCookie.path = "/"
-            response.addCookie(accessTokenCookie)
+            CookieUtil.addCookie(
+                response, 
+                "role", 
+                encodedRoleData, 
+                (jwtProperties.accessTokenExpiration / 1000).toInt(), 
+                false, 
+                true
+            )
+            
+            CookieUtil.addCookie(
+                response, 
+                "access_token", 
+                accessToken, 
+                (jwtProperties.accessTokenExpiration / 1000).toInt(), 
+                true, 
+                true
+            )
             
             val redirectUrl = UriComponentsBuilder.fromUriString(authorizedRedirectUri)
                 .queryParam("status", "SUCCESS")
                 .build()
                 .toUriString()
             
-            val refreshTokenCookie = Cookie("refresh_token", refreshToken)
-            refreshTokenCookie.isHttpOnly = true
-            refreshTokenCookie.secure = true
-            refreshTokenCookie.path = "/"
-            response.addCookie(refreshTokenCookie)
+            CookieUtil.addCookie(
+                response, 
+                "refresh_token", 
+                refreshToken, 
+                (jwtProperties.refreshTokenExpiration / 1000).toInt(), 
+                true, 
+                true
+            )
             
             response.sendRedirect(redirectUrl)
         }

--- a/backend/src/main/java/com/ll/hotel/standard/util/CookieUtil.kt
+++ b/backend/src/main/java/com/ll/hotel/standard/util/CookieUtil.kt
@@ -10,11 +10,13 @@ object CookieUtil {
         return cookies.firstOrNull { it.name == name }
     }
 
-    fun addCookie(response: HttpServletResponse, name: String, value: String, maxAge: Int) {
-        val cookie: Cookie = Cookie(name, value).apply {
+    fun addCookie(response: HttpServletResponse, name: String, value: String, maxAge: Int, 
+                  isHttpOnly: Boolean = true, isSecure: Boolean = false) {
+        val cookie = Cookie(name, value).apply {
             path = "/"
-            isHttpOnly = true
+            this.isHttpOnly = isHttpOnly
             this.maxAge = maxAge
+            this.secure = isSecure
         }
         response.addCookie(cookie)
     }

--- a/backend/src/main/java/com/ll/hotel/standard/util/CookieUtil.kt
+++ b/backend/src/main/java/com/ll/hotel/standard/util/CookieUtil.kt
@@ -3,6 +3,7 @@ package com.ll.hotel.standard.util
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.ResponseCookie
 
 object CookieUtil {
     fun getCookie(request: HttpServletRequest, name: String): Cookie? {
@@ -10,27 +11,39 @@ object CookieUtil {
         return cookies.firstOrNull { it.name == name }
     }
 
-    fun addCookie(response: HttpServletResponse, name: String, value: String, maxAge: Int, 
-                  isHttpOnly: Boolean = true, isSecure: Boolean = false) {
-        val cookie = Cookie(name, value).apply {
-            path = "/"
-            this.isHttpOnly = isHttpOnly
-            this.maxAge = maxAge
-            this.secure = isSecure
-        }
-        response.addCookie(cookie)
+    fun addCookie(
+        response: HttpServletResponse, 
+        name: String, 
+        value: String, 
+        maxAge: Int, 
+        isHttpOnly: Boolean = true, 
+        isSecure: Boolean = false, 
+        sameSite: String = "Lax"
+    ) {
+        val cookie = ResponseCookie.from(name, value)
+            .path("/")
+            .httpOnly(isHttpOnly)
+            .maxAge(maxAge.toLong())
+            .secure(isSecure)
+            .sameSite(sameSite)
+            .build()
+            
+        response.addHeader("Set-Cookie", cookie.toString())
     }
 
     fun deleteCookie(request: HttpServletRequest, response: HttpServletResponse, name: String) {
         val cookies = request.cookies ?: return
         cookies.filter { it.name == name }
-            .forEach { cookie ->
-                cookie.apply {
-                    value = ""
-                    path = "/"
-                    maxAge = 0
-                }
-                response.addCookie(cookie)
+            .forEach { _ ->
+                val cookie = ResponseCookie.from(name, "")
+                    .path("/")
+                    .maxAge(0)
+                    .httpOnly(true)
+                    .secure(true)
+                    .sameSite("Lax")
+                    .build()
+                    
+                response.addHeader("Set-Cookie", cookie.toString())
             }
     }
 }


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
- 기능에서 어떤 부분이 구현되었는지 설명해주세요
- 기존 다른 곳에서 하드코딩으로 중복적인 Cookie객체를 생성하던 부분 CookieUtil 객체를 사용해서 중앙 집중 형식으로 관리하도록 변경 
- SameSite을 설정함으로써 CSRF 공격 보안에 취약하던 부분 해결 (현재는 CSRF, XSS 를 전부 방어할 수 있는 완벽한 상태의 방식)
